### PR TITLE
App ID falls afoul of corodva's latest restriction

### DIFF
--- a/template/config.xml
+++ b/template/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.phonegap.my-app" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.phonegap.myapp" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>My App</name>
     <description>
         A basic Vue.js + Framework7 template for PhoneGap.

--- a/template/package.json
+++ b/template/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-app",
+  "name": "myapp",
   "version": "1.0.0",
   "description": "A blank PhoneGap template using Vue.js and Framework7",
   "author": "tommy-carlos williams <tommy@devgeeks.org>",


### PR DESCRIPTION
changed app id from `my-app` to `myapp`

Closes #20