### PR TITLE
Fix for live reload in the developer app

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -49,7 +49,7 @@ var webpackConfig = merge(baseWebpackConfig, {
       minify: {
         removeComments: true,
         collapseWhitespace: false,
-        removeAttributeQuotes: true,
+        removeAttributeQuotes: false,
         keepClosingSlash: true,
         // more options:
         // https://github.com/kangax/html-minifier#options-quick-reference

--- a/template/src/index.html
+++ b/template/src/index.html
@@ -25,7 +25,7 @@
   <body>
     <div id="app"></div>
     <noscript>JavaScript is required for this template.</noscript>
-    <script src="cordova.js"></script>
+    <script type="text/javascript" src="cordova.js"></script>
     <!-- built files will be auto injected -->
   </body>
 </html>


### PR DESCRIPTION
- removed `removeAttributeQuotes` minification
- changed `cordova.js` script tag to exactly match the one the dev app
  tries to replace
```
<script type="text/javascript" src="cordova.js"></script>
```

Fixes #12