### PR TITLE
Remove android-minSdkVersion entry

### DIFF
--- a/template/config.xml
+++ b/template/config.xml
@@ -19,7 +19,6 @@
         <preference name="windows-target-version" value="10.0" />
     </platform>
     <platform name="android">
-        <preference name="android-minSdkVersion" value="14" />
         <allow-intent href="market:*" />
         <icon density="ldpi" src="res/icon/android/drawable-ldpi-icon.png" />
         <icon density="mdpi" src="res/icon/android/drawable-mdpi-icon.png" />


### PR DESCRIPTION
CordovaLib requires minSdkVersion 16 so the template won't build, better remove it as in the future it will require another version